### PR TITLE
restrict jobs to only run npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # omg-js-testrunner
-Simple node service to run test jobs. Stores the results of the last 5 jobs in memory.
+Simple node service to run test jobs. The job can specify an npm script to run. 
+Stores the results of the last 5 jobs in memory.
 
 # API
 
@@ -9,9 +10,7 @@ POST http://localhost:3333/job
 {
 	"job": {
 		"id": "a6ff00e9feb18400551fef6c3e5900df",
-		"command": "npm",
-		"args": ["run", "integration-test"],
-		"cwd": "/Users/kevin/work/omg/omg-js"
+		"script": "integration-test"
 	}
 }
 ```

--- a/app.js
+++ b/app.js
@@ -5,23 +5,21 @@ const crypto = require('crypto')
 require('log-timestamp')
 
 const port = process.env.TESTRUNNER_PORT || 3333
-
-const ALLOWED_COMMANDS = ['npm', 'git']
+const cwd = process.env.TESTRUNNER_OMGJS_DIR || '/home/omg/omg-js'
 
 const app = express()
 app.use(bodyParser.json())
 
 app.post('/job', (req, res) => {
-  if (!ALLOWED_COMMANDS.includes(req.body.job.command)) {
-    res.status(422)
-    res.send(`Command '${req.body.job.command}' is not allowed`)
-    return
-  }
+  const job = req.body.job
 
-  req.body.job.id = req.body.job.id || randomId()
-  console.log(`starting new job: ${JSON.stringify(req.body.job)}`)
-  runner.start(req.body.job)
-  res.send(req.body.job.id)
+  job.id = job.id || randomId()
+  job.command = 'npm'
+  job.args = ['run', job.script]
+  job.cwd = cwd
+  console.log(`starting new job: ${JSON.stringify(job)}`)
+  runner.start(job)
+  res.send(job.id)
 })
 
 app.get('/job/:id/status', (req, res) => {


### PR DESCRIPTION
Changes:
- jobs will only run an npm script
- cwd is set in the container, cannot be overridden by jobs