### PR TITLE
add omg-js git sha tag to docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,16 @@ jobs:
       - run:
           name: publish to GCP container registry
           command: |
+            GIT_COMMIT_SHA=$(git rev-parse HEAD)
+
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
             gcloud -q auth configure-docker
+
             docker build -t testrunner .
-            docker tag testrunner gcr.io/omisego-development/omg-js-testrunner
+            docker tag testrunner gcr.io/omisego-development/omg-js-testrunner:testrunner-$GIT_COMMIT_SHA
             docker push gcr.io/omisego-development/omg-js-testrunner
+
+            # add tag for omg-js sha
+            gcloud container images add-tag \
+            gcr.io/omisego-development/omg-js-testrunner:testrunner-$GIT_COMMIT_SHA \
+            gcr.io/omisego-development/omg-js-testrunner:omg-js-$(cat ./OMG_JS_SHA)


### PR DESCRIPTION
### Note

This PR adds `omg-js-[:sha]` and `testrunner-[:sha]` to the docker published.
This is for easier tracking of the image in the GCP repo and whenever we are updating the helm development repo it will be easier to track. credit @unnawut for the idea.

### Test
- example CI job (unblock the branch filter): [here](https://app.circleci.com/pipelines/github/omgnetwork/omg-js-testrunner/11/workflows/8030cc28-3f0d-4248-8050-4d4b21c566e8/jobs/10)
- example image with the tags: [here](https://console.cloud.google.com/gcr/images/omisego-development/GLOBAL/omg-js-testrunner@sha256:995b3d0e090884138130eccdfde98c693be66ea855ecd04e53c8fa0518554bc6/details?tab=info&project=omisego-development)