### PR TITLE
feat: use short git sha instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - boolafish/short_git
 
 jobs:
   publish:
@@ -32,8 +32,3 @@ jobs:
             docker build -t testrunner .
             docker tag testrunner $TEST_RUNNER_TAG
             docker push $TEST_RUNNER_TAG
-
-            # add tag for omg-js sha that this image is using
-            gcloud container images add-tag \
-            $TEST_RUNNER_TAG \
-            gcr.io/omisego-development/omg-js-testrunner:with-omg-js-$(cat ./OMG_JS_SHA | head -c $GIT_SHA_SHORT_LENGTH)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,9 @@ jobs:
       - run:
           name: publish to GCP container registry
           command: |
-            GIT_COMMIT_SHA=$(git rev-parse HEAD)
-            TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:omg-js-testrunner-$GIT_COMMIT_SHA
+            GIT_SHA_SHORT_LENGTH=7
+            GIT_COMMIT_SHA=$(git rev-parse --short=$GIT_SHA_SHORT_LENGTH HEAD)
+            TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
 
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
             gcloud -q auth configure-docker
@@ -35,4 +36,4 @@ jobs:
             # add tag for omg-js sha that this image is using
             gcloud container images add-tag \
             $TEST_RUNNER_TAG \
-            gcr.io/omisego-development/omg-js-testrunner:with-omg-js-$(cat ./OMG_JS_SHA)
+            gcr.io/omisego-development/omg-js-testrunner:with-omg-js-$(cat ./OMG_JS_SHA | head -c $GIT_SHA_SHORT_LENGTH)


### PR DESCRIPTION
### Note
It is more common in our current infra setup to use short git sha.
Also the convension is to tag the sha directly without extra prefix.

ref: https://github.com/omgnetwork/helm-development/pull/416#issuecomment-675253153

### Test
- GCP image: [link](https://console.cloud.google.com/gcr/images/omisego-development/GLOBAL/omg-js-testrunner@sha256:c3a3b7af4f1f89b9b173cda7909baef762dd637443217c9859cca5770397d514/details?tab=info&project=omisego-development)
- example CI (remove branch filter): [link](https://app.circleci.com/jobs/github/omgnetwork/omg-js-testrunner/18)
